### PR TITLE
Dropdown Toggle: Normalize link appearance

### DIFF
--- a/scss/pack/seed-navbar/components/_navbar.scss
+++ b/scss/pack/seed-navbar/components/_navbar.scss
@@ -53,5 +53,10 @@
         }
       }
     }
+    .#{$seed-dropdown-toggle-namespace} {
+      -webkit-appearance: none;
+      -moz-appearance: none;
+      appearance: none;
+    }
   }
 }

--- a/test/component.navbar.js
+++ b/test/component.navbar.js
@@ -36,8 +36,18 @@ describe('seed-navbar: component: navbar', function() {
   });
 
   describe('integration', function() {
+    describe('seed-dropdown', function() {
+      it('should normalize the dropdown toggle appearance', function() {
+        var $o = output.$('.c-navbar .c-dropdown__toggle');
+
+        expect($o.exists()).to.be.true;
+        expect($o.prop('appearance')).to.exist;
+        expect($o.prop('appearance')).to.equal('none');
+      });
+    });
+
     describe('seed-nav', function() {
-      it('adjust the padding', function() {
+      it('should adjust the padding', function() {
         var $o = output.$('.c-navbar .c-nav__link');
 
         expect($o.exists()).to.be.true;


### PR DESCRIPTION
## Updates

This ensures that the toggle link doesn't get unexpected default styles if `type="button"` is applied to an `<a>` selector.