### PR TITLE
Collapse: Avoid being set globally

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,13 +54,13 @@
     "sass-pathfinder": "0.0.5",
     "seed-button": "0.1.16",
     "seed-dropdown": "0.0.8",
-    "seed-nav": "0.0.1",
-    "seed-publish": "0.1.1"
+    "seed-nav": "0.1.0",
+    "seed-publish": "0.2.0"
   },
   "devDependencies": {
     "mkdirp": "0.5.1",
-    "node-sass": "^3.10.0",
-    "seed-barista": "0.3.3",
-    "seed-bistro": "0.1.1"
+    "node-sass": "^4.5.3",
+    "seed-barista": "1.0.3",
+    "seed-bistro": "0.1.9"
   }
 }

--- a/scss/pack/seed-navbar/components/_navbar-collapse.scss
+++ b/scss/pack/seed-navbar/components/_navbar-collapse.scss
@@ -6,29 +6,30 @@
 @import "../config";
 
 @include export(seed-navbar) {
-  .#{$seed-navbar-collapse-namespace},
-  .#{$seed-navbar-item-namespace}.#{$seed-navbar-collapse-namespace} {
-    box-sizing: border-box;
-    display: none;
+  .#{$seed-navbar-item-namespace} {
+    &.#{$seed-navbar-collapse-namespace} {
+      box-sizing: border-box;
+      display: none;
 
-    @include breakpoint(md) {
-      display: block !important;
+      @include breakpoint(md) {
+        display: block !important;
+      }
+
+      // States
+      &.in,
+      &.show {
+        display: block;
+      }
     }
 
-    // States
-    &.in,
-    &.show {
-      display: block;
+    // Collapsing animation
+    &.#{$seed-navbar-collapsing-namespace} {
+      height: 0;
+      overflow: hidden;
+      position: relative;
+      transition-duration: 0.35s;
+      transition-property: height, visibility;
+      transition-timing-function: ease;
     }
-  }
-
-  // Collapsing animation
-  .#{$seed-navbar-collapsing-namespace} {
-    height: 0;
-    overflow: hidden;
-    position: relative;
-    transition-duration: 0.35s;
-    transition-property: height, visibility;
-    transition-timing-function: ease;
   }
 }

--- a/test/component.navbar-brand.js
+++ b/test/component.navbar-brand.js
@@ -2,39 +2,41 @@
 /* globals describe: true, it: true */
 'use strict';
 
-var barista = require('seed-barista');
-var expect = require('chai').expect;
+const barista = require('seed-barista');
+const expect = require('chai').expect;
 
 describe('seed-navbar: component: navbar-brand', function() {
   describe('base', function() {
-    var style = `
+    const style = `
       @import "./_index";
     `;
-    var output = barista({ content: style });
-    var $o = output.$('.c-navbar__brand');
+    const output = barista({ content: style });
+    const o = output.rule('.c-navbar__brand');
 
     it('should have box-sizing reset', function() {
-      expect($o.prop('box-sizing')).to.equal('border-box');
+      expect(o.prop('box-sizing')).to.equal('border-box');
     });
 
     it('should have correct display property', function() {
-      expect($o.prop('display')).to.equal('inline-block');
+      expect(o.prop('display')).to.equal('inline-block');
     });
 
     it('should reset line-height', function() {
-      expect($o.prop('line-height')).to.equal('inherit');
+      expect(o.prop('line-height')).to.equal('inherit');
     });
 
     it('should increase the font-size slightly be default', function() {
-      expect($o.prop('font-size')).to.be.equal('1.25rem');
+      expect(o.prop('font-size')).to.be.equal('1.25rem');
     });
 
     it('should have a default margin-right', function() {
-      expect(parseInt($o.prop('margin-right').replace('rem', ''), 10)).to.be.above(0);
+      expect(
+        parseInt(o.prop('margin-right').replace('rem', ''), 10)
+      ).to.be.above(0);
     });
 
     it('should have white-space reset', function() {
-      expect($o.prop('white-space')).to.be.equal('nowrap');
+      expect(o.prop('white-space')).to.be.equal('nowrap');
     });
   });
 });

--- a/test/component.navbar-collapse.js
+++ b/test/component.navbar-collapse.js
@@ -2,37 +2,48 @@
 /* globals describe: true, it: true */
 'use strict';
 
-var barista = require('seed-barista');
-var expect = require('chai').expect;
+const barista = require('seed-barista');
+const expect = require('chai').expect;
 
 describe('seed-navbar: component: collapse', function() {
   describe('base', function() {
-    var style = `
+    const style = `
       @import "./_index";
     `;
-    var output = barista({ content: style });
-    var $o = output.$('.collapse');
+    const output = barista({ content: style });
+    const o = output.rule('.c-navbar__item.collapse');
+
+    it('should not style default Bootstrap collapse rules', function() {
+      expect(output.rule('.collapse').exists()).to.be.false;
+      expect(output.rule('.in').exists()).to.be.false;
+      expect(output.rule('.collapse.in').exists()).to.be.false;
+      expect(output.rule('.collapsing').exists()).to.be.false;
+    });
 
     it('should have box-sizing reset', function() {
-      expect($o.prop('box-sizing')).to.equal('border-box');
+      expect(o.prop('box-sizing')).to.equal('border-box');
     });
 
     it('should be hidden by default', function() {
-      expect($o.prop('display')).to.equal('none');
+      expect(o.prop('display')).to.equal('none');
     });
 
     it('should be visible when triggered', function() {
-      expect(output.$('.collapse.in').prop('display')).to.equal('block');
-      expect(output.$('.collapse.show').prop('display')).to.equal('block');
+      expect(
+        output.rule('.c-navbar__item.collapse.in').prop('display')
+      ).to.equal('block');
+      expect(
+        output.rule('.c-navbar__item.collapse.show').prop('display')
+      ).to.equal('block');
     });
 
     it('should have collapsing animation class', function() {
-      var $o = output.$('.collapsing');
+      const o = output.rule('.c-navbar__item.collapsing');
 
-      expect($o.exists()).to.be.true;
-      expect($o.prop('height')).to.exist;
-      expect($o.prop('transition-duration')).to.exist;
-      expect($o.prop('transition-property')).to.exist;
+      expect(o.exists()).to.be.true;
+      expect(o.prop('height')).to.exist;
+      expect(o.prop('transition-duration')).to.exist;
+      expect(o.prop('transition-property')).to.exist;
     });
   });
 });

--- a/test/component.navbar-header.js
+++ b/test/component.navbar-header.js
@@ -2,35 +2,35 @@
 /* globals describe: true, it: true */
 'use strict';
 
-var barista = require('seed-barista');
-var expect = require('chai').expect;
+const barista = require('seed-barista');
+const expect = require('chai').expect;
 
 describe('seed-navbar: component: navbar-header', function() {
   describe('base', function() {
-    var style = `
+    const style = `
       @import "./_index";
     `;
-    var output = barista({ content: style });
-    var $o = output.$('.c-navbar__header');
+    const output = barista({ content: style });
+    const o = output.rule('.c-navbar__header');
 
     it('should have box-sizing reset', function() {
-      expect($o.prop('box-sizing')).to.equal('border-box');
+      expect(o.prop('box-sizing')).to.equal('border-box');
     });
 
     it('should have correct flex properties', function() {
-      expect($o.prop('align-items')).to.equal('center');
-      expect($o.prop('display')).to.equal('flex');
-      expect($o.prop('flex-direction')).to.equal('row');
-      expect($o.prop('flex-wrap')).to.equal('nowrap');
-      expect($o.prop('justify-content')).to.equal('flex-start');
+      expect(o.prop('align-items')).to.equal('center');
+      expect(o.prop('display')).to.equal('flex');
+      expect(o.prop('flex-direction')).to.equal('row');
+      expect(o.prop('flex-wrap')).to.equal('nowrap');
+      expect(o.prop('justify-content')).to.equal('flex-start');
     });
 
     it('should have position of relative', function() {
-      expect($o.prop('position')).to.equal('relative');
+      expect(o.prop('position')).to.equal('relative');
     });
 
     it('should have a min-height defined', function() {
-      expect(parseInt($o.prop('min-height'), 10)).to.be.above(0);
+      expect(parseInt(o.prop('min-height'), 10)).to.be.above(0);
     });
   });
 });

--- a/test/component.navbar-item.js
+++ b/test/component.navbar-item.js
@@ -2,35 +2,35 @@
 /* globals describe: true, it: true */
 'use strict';
 
-var barista = require('seed-barista');
-var expect = require('chai').expect;
+const barista = require('seed-barista');
+const expect = require('chai').expect;
 
 describe('seed-navbar: component: navbar-item', function() {
   describe('base', function() {
-    var style = `
+    const style = `
       @import "./_index";
     `;
-    var output = barista({ content: style });
-    var $o = output.$('.c-navbar__item');
+    const output = barista({ content: style });
+    const o = output.rule('.c-navbar__item');
 
     it('should have box-sizing reset', function() {
-      expect($o.prop('box-sizing')).to.equal('border-box');
+      expect(o.prop('box-sizing')).to.equal('border-box');
     });
 
     it('should have correct display property', function() {
-      expect($o.prop('display')).to.equal('block');
+      expect(o.prop('display')).to.equal('block');
     });
   });
 
   describe('modifiers', function() {
-    var style = `
+    const style = `
       @import "./_index";
     `;
-    var output = barista({ content: style });
+    const output = barista({ content: style });
 
     it('should have correct left/right align modifiers', function() {
-      var l = output.$('.c-navbar__item--left');
-      var r = output.$('.c-navbar__item--right');
+      const l = output.rule('.c-navbar__item--left');
+      const r = output.rule('.c-navbar__item--right');
 
       expect(l.exists()).to.be.true;
       expect(l.prop('margin-right')).to.equal('auto');

--- a/test/component.navbar-toggle-icon.js
+++ b/test/component.navbar-toggle-icon.js
@@ -2,36 +2,36 @@
 /* globals describe: true, it: true */
 'use strict';
 
-var barista = require('seed-barista');
-var expect = require('chai').expect;
+const barista = require('seed-barista');
+const expect = require('chai').expect;
 
 describe('seed-navbar: component: navbar-toggle-icon', function() {
   describe('base', function() {
-    var style = `
+    const style = `
       @import "./_index";
     `;
-    var output = barista({ content: style });
-    var $o = output.$('.c-navbar__toggle-icon');
+    const output = barista({ content: style });
+    const o = output.rule('.c-navbar__toggle-icon');
 
     it('should have box-sizing reset', function() {
-      expect($o.prop('box-sizing')).to.equal('border-box');
+      expect(o.prop('box-sizing')).to.equal('border-box');
     });
 
     it('should have correct display', function() {
-      expect($o.prop('display')).to.equal('block');
+      expect(o.prop('display')).to.equal('block');
     });
 
     it('should have correct position', function() {
-      expect($o.prop('position')).to.equal('relative');
+      expect(o.prop('position')).to.equal('relative');
     });
 
     it('should have sizing defined', function() {
-      expect($o.prop('height')).to.exist;
-      expect($o.prop('width')).to.exist;
+      expect(o.prop('height')).to.exist;
+      expect(o.prop('width')).to.exist;
     });
 
     it('should have a color defined', function() {
-      expect($o.prop('color')).to.exist;
+      expect(o.prop('color')).to.exist;
     });
   });
 });

--- a/test/component.navbar-toggle.js
+++ b/test/component.navbar-toggle.js
@@ -2,24 +2,24 @@
 /* globals describe: true, it: true */
 'use strict';
 
-var barista = require('seed-barista');
-var expect = require('chai').expect;
+const barista = require('seed-barista');
+const expect = require('chai').expect;
 
 describe('seed-navbar: component: navbar-toggle', function() {
   describe('base', function() {
-    var style = `
+    const style = `
       @import "./_index";
     `;
-    var output = barista({ content: style });
-    var $o = output.$('.c-navbar__toggle');
+    const output = barista({ content: style });
+    const o = output.rule('.c-navbar__toggle');
 
     it('should have box-sizing reset', function() {
-      expect($o.prop('box-sizing')).to.equal('border-box');
+      expect(o.prop('box-sizing')).to.equal('border-box');
     });
 
     it('should vertical center align child item(s)', function() {
-      expect($o.prop('align-items')).to.equal('center');
-      expect($o.prop('display')).to.equal('flex');
+      expect(o.prop('align-items')).to.equal('center');
+      expect(o.prop('display')).to.equal('flex');
     });
   });
 });

--- a/test/component.navbar.js
+++ b/test/component.navbar.js
@@ -2,57 +2,57 @@
 /* globals describe: true, it: true */
 'use strict';
 
-var barista = require('seed-barista');
-var expect = require('chai').expect;
+const barista = require('seed-barista');
+const expect = require('chai').expect;
 
 describe('seed-navbar: component: navbar', function() {
-  var style = `
+  const style = `
     @import "./_index";
   `;
-  var output = barista({ content: style });
+  const output = barista({ content: style });
 
   describe('base', function() {
-    var $o = output.$('.c-navbar');
+    const o = output.rule('.c-navbar');
 
     it('should have box-sizing reset', function() {
-      expect($o.prop('box-sizing')).to.equal('border-box');
+      expect(o.prop('box-sizing')).to.equal('border-box');
     });
 
     it('should have correct flex properties', function() {
-      expect($o.prop('align-items')).to.equal('center');
-      expect($o.prop('display')).to.equal('block'); // Becomes flex @md
-      expect($o.prop('flex-direction')).to.equal('row');
-      expect($o.prop('flex-wrap')).to.equal('nowrap');
-      expect($o.prop('justify-content')).to.equal('flex-start');
+      expect(o.prop('align-items')).to.equal('center');
+      expect(o.prop('display')).to.equal('block'); // Becomes flex @md
+      expect(o.prop('flex-direction')).to.equal('row');
+      expect(o.prop('flex-wrap')).to.equal('nowrap');
+      expect(o.prop('justify-content')).to.equal('flex-start');
     });
 
     it('should have position of relative', function() {
-      expect($o.prop('position')).to.equal('relative');
+      expect(o.prop('position')).to.equal('relative');
     });
 
     it('should have a min-height defined', function() {
-      expect(parseInt($o.prop('min-height'), 10)).to.be.above(0);
+      expect(parseInt(o.prop('min-height'), 10)).to.be.above(0);
     });
   });
 
   describe('integration', function() {
     describe('seed-dropdown', function() {
       it('should normalize the dropdown toggle appearance', function() {
-        var $o = output.$('.c-navbar .c-dropdown__toggle');
+        const o = output.rule('.c-navbar .c-dropdown__toggle');
 
-        expect($o.exists()).to.be.true;
-        expect($o.prop('appearance')).to.exist;
-        expect($o.prop('appearance')).to.equal('none');
+        expect(o.exists()).to.be.true;
+        expect(o.prop('appearance')).to.exist;
+        expect(o.prop('appearance')).to.equal('none');
       });
     });
 
     describe('seed-nav', function() {
       it('should adjust the padding', function() {
-        var $o = output.$('.c-navbar .c-nav__link');
+        const o = output.rule('.c-navbar .c-nav__link');
 
-        expect($o.exists()).to.be.true;
-        expect($o.prop('padding-left')).to.exist;
-        expect($o.prop('padding-right')).to.exist;
+        expect(o.exists()).to.be.true;
+        expect(o.prop('padding-left')).to.exist;
+        expect(o.prop('padding-right')).to.exist;
       });
     });
   });


### PR DESCRIPTION
## Updates

Primary CSS change is:

```
.collapse -> .c-navbar__item.collapse
.collapsing -> .c-navbar__item.collapsing
```

* Change scope of Bootstrap's `collapse` related rules to be scoped to nav-item component
* Write tests for collapse
* Update dependencies to latest versions
* Refactor test .js files to more ES6 conventions + prettier

Resolves: https://github.com/helpscout/seed-navbar/issues/2