### PR TITLE
NavBarCollapse - Fix for Bootstrap

### DIFF
--- a/scss/pack/seed-navbar/components/_navbar-collapse.scss
+++ b/scss/pack/seed-navbar/components/_navbar-collapse.scss
@@ -11,8 +11,13 @@
       box-sizing: border-box;
       display: none;
 
+      // For Bootstrap
+      // https://github.com/twbs/bootstrap/blob/master/less/navbar.less#L68
       @include breakpoint(md) {
         display: block !important;
+        height: auto !important;
+        overflow: visible !important;
+        padding-bottom: 0; // Override default setting
       }
 
       // States

--- a/test/component.navbar-collapse.js
+++ b/test/component.navbar-collapse.js
@@ -45,5 +45,14 @@ describe('seed-navbar: component: collapse', function() {
       expect(o.prop('transition-duration')).to.exist;
       expect(o.prop('transition-property')).to.exist;
     });
+
+    it('should have Bootstrap overrides for md breakpoint', () => {
+      const o = output.rule('.c-navbar__item.collapse').at(['min', '768px']);
+
+      expect(o.prop('display')).to.equal('block')
+      expect(o.prop('height')).to.equal('auto')
+      expect(o.prop('overflow')).to.equal('visible')
+      expect(o.prop('padding-bottom')).to.equal('0')
+    });
   });
 });


### PR DESCRIPTION
This update resolves the Bootstrap-based transition between smaller->larger
viewport sizes for `.navbar-collapse`.

Since this component was designed to work with Bootstrap's JS, I've
implemented Bootstrap's solution.

https://github.com/twbs/bootstrap/blob/master/less/navbar.less#L68

Their solution was to "hard code" certain values at the `md` breakpoint
by using `!important`.

A test has been added to check for these values.

Resolves: https://github.com/helpscout/seed-navbar/issues/4

(Thanks a bunch @dehamzah!)